### PR TITLE
fixing some field types to align with our es mappings

### DIFF
--- a/rules-emerging-threats/2022/Exploits/CVE-2022-27925/web_cve_2022_27925_exploit.yml
+++ b/rules-emerging-threats/2022/Exploits/CVE-2022-27925/web_cve_2022_27925_exploit.yml
@@ -31,7 +31,7 @@ detection:
     selection_shell:
         cs-uri-query|contains: '/zimbraAdmin/'
         cs-uri-query|endswith: '.jsp'
-        sc-status|contains: '200'
+        sc-status: 200
     condition: 1 of selection_*
 falsepositives:
     - Unknown

--- a/rules/cloud/azure/signin_logs/azure_ad_sign_ins_from_noncompliant_devices.yml
+++ b/rules/cloud/azure/signin_logs/azure_ad_sign_ins_from_noncompliant_devices.yml
@@ -14,7 +14,7 @@ logsource:
     service: signinlogs
 detection:
     selection:
-        DeviceDetail.isCompliant: 'false'
+        DeviceDetail.isCompliant: false
     condition: selection
 falsepositives:
     - Unknown

--- a/rules/network/zeek/zeek_dns_mining_pools.yml
+++ b/rules/network/zeek/zeek_dns_mining_pools.yml
@@ -93,7 +93,7 @@ detection:
             - '127.0.0.1'
             - '0.0.0.0'
     exclude_rejected:
-        rejected: 'true'
+        rejected: true
     condition: selection and not 1 of exclude_*
 fields:
     - id.orig_h


### PR DESCRIPTION
really only thing to review is removing `contains` modifier on http status code 200 check. We can't do it because that field is numerical in our mappings. Not sure if that breaks the logic of the rule