### PR TITLE
Cloud trail rules

### DIFF
--- a/rules/cloud/aws/cloudtrail/aws_cloudtrail_ssm_malicious_usage.yml
+++ b/rules/cloud/aws/cloudtrail/aws_cloudtrail_ssm_malicious_usage.yml
@@ -11,6 +11,8 @@ tags:
     - attack.privilege-escalation
     - attack.t1566
     - attack.t1566.002
+    - vigilant.disabled
+    - vigilant.review
 logsource:
     product: aws
     service: cloudtrail

--- a/rules/cloud/aws/cloudtrail/aws_ec2_startup_script_change.yml
+++ b/rules/cloud/aws/cloudtrail/aws_ec2_startup_script_change.yml
@@ -18,7 +18,7 @@ logsource:
 detection:
     selection_source:
         eventSource: ec2.amazonaws.com
-        requestParameters.attribute: 'userData'
+        requestParameters|contains: 'attribute=userData'
         eventName: ModifyInstanceAttribute
     condition: selection_source
 falsepositives:

--- a/rules/cloud/aws/cloudtrail/aws_ecs_task_definition_cred_endpoint_query.yml
+++ b/rules/cloud/aws/cloudtrail/aws_ecs_task_definition_cred_endpoint_query.yml
@@ -14,6 +14,8 @@ modified: 2023-04-24
 tags:
     - attack.persistence
     - attack.t1525
+    - vigilant.disabled
+    - vigilant.review
 logsource:
     product: aws
     service: cloudtrail

--- a/rules/cloud/aws/cloudtrail/aws_iam_s3browser_templated_s3_bucket_policy_creation.yml
+++ b/rules/cloud/aws/cloudtrail/aws_iam_s3browser_templated_s3_bucket_policy_creation.yml
@@ -12,6 +12,7 @@ tags:
     - attack.t1059.009
     - attack.persistence
     - attack.t1078.004
+    - vigilant.disabled
 logsource:
     product: aws
     service: cloudtrail

--- a/rules/cloud/aws/cloudtrail/aws_rds_change_master_password.yml
+++ b/rules/cloud/aws/cloudtrail/aws_rds_change_master_password.yml
@@ -10,6 +10,8 @@ modified: 2022-10-05
 tags:
     - attack.exfiltration
     - attack.t1020
+    - vigilant.disabled
+    - vigilant.review
 logsource:
     product: aws
     service: cloudtrail

--- a/rules/cloud/aws/cloudtrail/aws_rds_public_db_restore.yml
+++ b/rules/cloud/aws/cloudtrail/aws_rds_public_db_restore.yml
@@ -16,7 +16,7 @@ logsource:
 detection:
     selection_source:
         eventSource: rds.amazonaws.com
-        responseElements.publiclyAccessible: 'true'
+        responseElements|contais: 'publiclyAccessible=true'
         eventName: RestoreDBInstanceFromDBSnapshot
     condition: selection_source
 falsepositives:


### PR DESCRIPTION
both `requestParameters` and `responseParameters` are fields we have in Elasticsearch but they are keyword fields consisting of compressed dict blobs. For example, we have the following two fields for `requestParameters`

`aws.cloudtrail.request_parameters` (keyword):
```
{Filter={Not={Or=[{Dimensions={Values=[Credit], Key=RECORD_TYPE}}, {Dimensions={Values=[Refund], Key=RECORD_TYPE}}]}}, TimePeriod={Start=2025-01-24, End=2025-02-01}, Metric=NET_UNBLENDED_COST, Granularity=MONTHLY}
```
`aws.cloudtrail.flattened.request_parameters` (flattened):
```
{ "Metric": "NET_UNBLENDED_COST", "Granularity": "MONTHLY", "Filter": { "Not": { "Or": [ { "Dimensions": { "Values": [ "Credit" ], "Key": "RECORD_TYPE" } }, { "Dimensions": { "Values": [ "Refund" ], "Key": "RECORD_TYPE" } } ] } }, "TimePeriod": { "Start": "2025-01-24", "End": "2025-02-01" } }
```

so when a rule has a query on one of these fields with TWO levels or deeper, we simply can't do it with this current data model. When it only goes one level deep we can make the following change:
```
requestParameters.attribute: 'userData'
```
becomes
```
requestParameters|contains: 'attribute=userData'
```

The ultimate solution to this problem isn't to disable rules, it's to parse out these hierarchical fields on ingest but until we determine these rules have enough value to warrant that ingest work, we'll disable them with `vigilant.review`