### PR TITLE
Update aws_sts_getsessiontoken_misuse.yml

### DIFF
--- a/rules/cloud/aws/cloudtrail/aws_sts_getsessiontoken_misuse.yml
+++ b/rules/cloud/aws/cloudtrail/aws_sts_getsessiontoken_misuse.yml
@@ -14,6 +14,8 @@ tags:
     - attack.t1548
     - attack.t1550
     - attack.t1550.001
+    - vigilant.disabled
+    - vigilant.elastic_duplicate
 logsource:
     product: aws
     service: cloudtrail


### PR DESCRIPTION
disabling this in favor of the elastic version of the same rule_id https://github.com/VigilantSec/detection-rules/blob/main/rules/integrations/aws/privilege_escalation_sts_getsessiontoken_abuse.toml