### PR TITLE
Update file_event_win_susp_homoglyph_filename.yml

### DIFF
--- a/rules/windows/file/file_event/file_event_win_susp_homoglyph_filename.yml
+++ b/rules/windows/file/file_event/file_event_win_susp_homoglyph_filename.yml
@@ -19,8 +19,8 @@ logsource:
     category: file_event
     product: windows
 detection:
-    selection_upper:
-        TargetFilename|contains:
+    selection:
+        file.name|contains:
             - "\u0410" # А/A
             - "\u0412" # В/B
             - "\u0415" # Е/E
@@ -54,8 +54,6 @@ detection:
             - "\u03a4" # Τ/T
             - "\u03a5" # Υ/Y
             - "\u03a7" # Χ/X
-    selection_lower:
-        TargetFilename|contains:
             - "\u0430" # а/a
             - "\u0435" # е/e
             - "\u043e" # о/o
@@ -71,7 +69,7 @@ detection:
             - "\u051b" # ԛ/q
             - "\u051d" # ԝ/w
             - "\u03bf" # ο/o
-    condition: 1 of selection_*
+    condition: selection
 falsepositives:
     - File names with legitimate Cyrillic text. Will likely require tuning (or not be usable) in countries where these alphabets are in use.
 level: medium


### PR DESCRIPTION
rule is timing out on prod so lighten the query load at the expense of not catching path/directories containing homoglyphs, only filenames