### PR TITLE
Demote azure mfa interupt signal

### DIFF
--- a/rules/cloud/azure/signin_logs/azure_mfa_interrupted.yml
+++ b/rules/cloud/azure/signin_logs/azure_mfa_interrupted.yml
@@ -13,7 +13,6 @@ tags:
     - attack.t1078.004
     - attack.t1110
     - attack.t1621
-    - vigilant.alerting.identity_risk
 logsource:
     product: azure
     service: signinlogs


### PR DESCRIPTION
Remove the vigilant identity_risk tag from a signal that is contributing to noise and has little unique value in detections.

It tends to coincide with a particular different signal (new MFA method add) that leads to a lot of 2x identity_risk signal hits.