### PR TITLE
Add vigilant.beta tag to new gcp workspace signals

### DIFF
--- a/rules/cloud/gcp/gworkspace/gcp_gworkspace_application_access_levels_modified.yml
+++ b/rules/cloud/gcp/gworkspace/gcp_gworkspace_application_access_levels_modified.yml
@@ -14,6 +14,7 @@ tags:
     - attack.persistence
     - attack.privilege-escalation
     - attack.t1098.003
+    - vigilant.beta.identity_risk
 logsource:
     product: gcp
     service: google_workspace.admin

--- a/rules/cloud/gcp/gworkspace/gcp_gworkspace_application_removed.yml
+++ b/rules/cloud/gcp/gworkspace/gcp_gworkspace_application_removed.yml
@@ -11,6 +11,7 @@ date: 2021-08-26
 modified: 2023-10-11
 tags:
     - attack.impact
+    - vigilant.beta.identity_risk
 logsource:
     product: gcp
     service: google_workspace.admin

--- a/rules/cloud/gcp/gworkspace/gcp_gworkspace_granted_domain_api_access.yml
+++ b/rules/cloud/gcp/gworkspace/gcp_gworkspace_granted_domain_api_access.yml
@@ -11,6 +11,7 @@ modified: 2023-10-11
 tags:
     - attack.persistence
     - attack.t1098
+    - vigilant.beta.identity_risk
 logsource:
     product: gcp
     service: google_workspace.admin

--- a/rules/cloud/gcp/gworkspace/gcp_gworkspace_mfa_disabled.yml
+++ b/rules/cloud/gcp/gworkspace/gcp_gworkspace_mfa_disabled.yml
@@ -11,6 +11,7 @@ date: 2021-08-26
 modified: 2023-10-11
 tags:
     - attack.impact
+    - vigilant.beta.identity_risk
 logsource:
     product: gcp
     service: google_workspace.admin

--- a/rules/cloud/gcp/gworkspace/gcp_gworkspace_role_modified_or_deleted.yml
+++ b/rules/cloud/gcp/gworkspace/gcp_gworkspace_role_modified_or_deleted.yml
@@ -10,6 +10,7 @@ date: 2021-08-24
 modified: 2023-10-11
 tags:
     - attack.impact
+    - vigilant.beta.identity_risk
 logsource:
     product: gcp
     service: google_workspace.admin

--- a/rules/cloud/gcp/gworkspace/gcp_gworkspace_role_privilege_deleted.yml
+++ b/rules/cloud/gcp/gworkspace/gcp_gworkspace_role_privilege_deleted.yml
@@ -10,6 +10,7 @@ date: 2021-08-24
 modified: 2023-10-11
 tags:
     - attack.impact
+    - vigilant.beta.identity_risk
 logsource:
     product: gcp
     service: google_workspace.admin

--- a/rules/cloud/gcp/gworkspace/gcp_gworkspace_user_granted_admin_privileges.yml
+++ b/rules/cloud/gcp/gworkspace/gcp_gworkspace_user_granted_admin_privileges.yml
@@ -11,6 +11,7 @@ modified: 2023-10-11
 tags:
     - attack.persistence
     - attack.t1098
+    - vigilant.beta.identity_risk
 logsource:
     product: gcp
     service: google_workspace.admin


### PR DESCRIPTION
For 7 new, soon to be deployed sigma google workspace rules, add the vigilant.beta.identity_risk tag. 

Some of these rules may be helpful for identity alerting, or redundant to corresponding elastic google rules, but unlike the elastic rules, we have no data on their noise level yet. Therefore the beta tag is appropriate.