### PR TITLE
Disable: System Information Discovery Via Sysctl - MacOS

### DIFF
--- a/rules/macos/process_creation/proc_creation_macos_sysctl_discovery.yml
+++ b/rules/macos/process_creation/proc_creation_macos_sysctl_discovery.yml
@@ -19,6 +19,7 @@ tags:
     - attack.t1497.001
     - attack.discovery
     - attack.t1082
+    - vigilant.disabled
 logsource:
     product: macos
     category: process_creation


### PR DESCRIPTION
Unfortunately action1 is doing tens of thousands of these actions on mac devices and there is nothing in the logs we can use to identify this due to the process tree being `action1` -> `bash` -> `sysctl` and docs only containing parent process info. 