### PR TITLE
Add creation filter to "Suspicious Screensaver Binary File Creation" rule

### DIFF
--- a/rules/windows/file/file_event/file_event_win_creation_scr_binary_file.yml
+++ b/rules/windows/file/file_event/file_event_win_creation_scr_binary_file.yml
@@ -18,6 +18,7 @@ logsource:
 detection:
     selection:
         TargetFilename|endswith: '.scr'
+        eventName: 'creation'
     filter_generic:
         Image|endswith:
             - '\Kindle.exe'


### PR DESCRIPTION
This rule clearly intends to only catch creations but is catching quite a bit of other CRUD actions that produce false positives. I would update the upstream SigmaHQ but I do not think this logic is common in all systems as this is an ECS paradigm we are following for that field. 